### PR TITLE
move psychic skills to new template

### DIFF
--- a/module/actor/character-sheet.js
+++ b/module/actor/character-sheet.js
@@ -21,8 +21,8 @@ export class WwnActorSheetCharacter extends WwnActorSheet {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["wwn", "sheet", "actor", "character"],
       template: "systems/wwn/templates/actors/character-sheet.html",
-      width: 730,
-      height: 625,
+      width: 800,
+      height: 730,
       resizable: false,
       tabs: [
         {
@@ -38,7 +38,7 @@ export class WwnActorSheetCharacter extends WwnActorSheet {
    * Organize and classify Owned Items for Character sheets
    * @private
    */
-   _prepareItems(data) {
+  _prepareItems(data) {
     // Partition items by category
     let [items, weapons, armors, abilities, spells, arts, foci] = this.actor.data.items.reduce(
       (arr, item) => {

--- a/templates/actors/partials/character-attributes-tab.html
+++ b/templates/actors/partials/character-attributes-tab.html
@@ -379,6 +379,62 @@
                         data-dtype="Number" />
                 </div>
             </li>
+            {{#if config.psychicSkills}}
+            <li class="attribute skills" data-skills="biopsionics">
+                <h4 class="attribute-name box-title" title="{{ localize 'WWN.skills.desc.biopsionics' }}">
+                    <a>{{ localize "WWN.skills.biopsionics" }}</a>
+                </h4>
+                <div class="form-fields select-attribute selectAttribute">
+                    <select name="data.skills.biopsionics.stat">
+                    {{#select data.skills.biopsionics.stat}}
+                    {{#each config.scores as |stat a|}}
+                    <option value="{{a}}">{{stat}}</option>
+                    {{/each}}
+                    {{/select}}
+                    </select>
+                </div>
+                <div class="attribute-value">
+                    <input name="data.skills.biopsionics.value" type="number" value="{{data.skills.biopsionics.value}}"
+                        data-dtype="Number" />
+                </div>
+            </li>
+            <li class="attribute skills" data-skills="metapsionics">
+                <h4 class="attribute-name box-title" title="{{ localize 'WWN.skills.desc.metapsionics' }}">
+                    <a>{{ localize "WWN.skills.metapsionics" }}</a>
+                </h4>
+                <div class="form-fields select-attribute selectAttribute">
+                    <select name="data.skills.metapsionics.stat">
+                    {{#select data.skills.metapsionics.stat}}
+                    {{#each config.scores as |stat a|}}
+                    <option value="{{a}}">{{stat}}</option>
+                    {{/each}}
+                    {{/select}}
+                    </select>
+                </div>
+                <div class="attribute-value">
+                    <input name="data.skills.metapsionics.value" type="number" value="{{data.skills.metapsionics.value}}"
+                        data-dtype="Number" />
+                </div>
+            </li>
+            <li class="attribute skills" data-skills="precognition">
+                <h4 class="attribute-name box-title" title="{{ localize 'WWN.skills.desc.precognition' }}">
+                    <a>{{ localize "WWN.skills.precognition" }}</a>
+                </h4>
+                <div class="form-fields select-attribute selectAttribute">
+                    <select name="data.skills.precognition.stat">
+                    {{#select data.skills.precognition.stat}}
+                    {{#each config.scores as |stat a|}}
+                    <option value="{{a}}">{{stat}}</option>
+                    {{/each}}
+                    {{/select}}
+                    </select>
+                </div>
+                <div class="attribute-value">
+                    <input name="data.skills.precognition.value" type="number" value="{{data.skills.precognition.value}}"
+                        data-dtype="Number" />
+                </div>
+            </li>
+            {{/if}}
         </ul>
     </div>
     <div class="attribute-group skill-group">
@@ -563,6 +619,62 @@
                         data-dtype="Number" />
                 </div>
             </li>
+            {{#if config.psychicSkills}}
+            <li class="attribute skills" data-skills="telekinesis">
+                <h4 class="attribute-name box-title" title="{{ localize 'WWN.skills.desc.telekinesis' }}">
+                    <a>{{ localize "WWN.skills.telekinesis" }}</a>
+                </h4>
+                <div class="form-fields select-attribute selectAttribute">
+                    <select name="data.skills.telekinesis.stat">
+                    {{#select data.skills.telekinesis.stat}}
+                    {{#each config.scores as |stat a|}}
+                    <option value="{{a}}">{{stat}}</option>
+                    {{/each}}
+                    {{/select}}
+                    </select>
+                </div>
+                <div class="attribute-value">
+                    <input name="data.skills.telekinesis.value" type="number" value="{{data.skills.telekinesis.value}}"
+                        data-dtype="Number" />
+                </div>
+            </li>
+            <li class="attribute skills" data-skills="telepathy">
+                <h4 class="attribute-name box-title" title="{{ localize 'WWN.skills.desc.telepathy' }}">
+                    <a>{{ localize "WWN.skills.telepathy" }}</a>
+                </h4>
+                <div class="form-fields select-attribute selectAttribute">
+                    <select name="data.skills.telepathy.stat">
+                    {{#select data.skills.telepathy.stat}}
+                    {{#each config.scores as |stat a|}}
+                    <option value="{{a}}">{{stat}}</option>
+                    {{/each}}
+                    {{/select}}
+                    </select>
+                </div>
+                <div class="attribute-value">
+                    <input name="data.skills.telepathy.value" type="number" value="{{data.skills.telepathy.value}}"
+                        data-dtype="Number" />
+                </div>
+            </li>
+            <li class="attribute skills" data-skills="teleportation">
+                <h4 class="attribute-name box-title" title="{{ localize 'WWN.skills.desc.teleportation' }}">
+                    <a>{{ localize "WWN.skills.teleportation" }}</a>
+                </h4>
+                <div class="form-fields select-attribute selectAttribute">
+                    <select name="data.skills.teleportation.stat">
+                    {{#select data.skills.precognition.stat}}
+                    {{#each config.scores as |stat a|}}
+                    <option value="{{a}}">{{stat}}</option>
+                    {{/each}}
+                    {{/select}}
+                    </select>
+                </div>
+                <div class="attribute-value">
+                    <input name="data.skills.teleportation.value" type="number" value="{{data.skills.teleportation.value}}"
+                        data-dtype="Number" />
+                </div>
+            </li>
+            {{/if}}
             <li class="attribute skills">
                 <h4 class="attribute-name box-title" title="WWN.skills.unspentPointsHint">
                     <a>{{ localize "WWN.skills.unspentPoints" }}</a>

--- a/wwn.css
+++ b/wwn.css
@@ -90,7 +90,7 @@
   .wwn.sheet.actor .sheet-tabs {
     position: absolute;
     transform: rotate(90deg);
-    top: 433px;
+    top: 538px;
     right: -179px;
     width: 340px;
     border-top: none;
@@ -208,7 +208,7 @@
     padding-left: 0px;
     height: 30px;
     line-height: 30px;
-    width: 170px;
+    width: 200px;
     margin-bottom: 0px;
   }
   .wwn.sheet.actor .sheet-body .attribute-group.skill-group .attributes .attribute.skills {


### PR DESCRIPTION
Looks like the template where psychic skills were being rendered is not used anymore. I moved them to the new template, but the issue is that when psychic skills are not there the sheet will have some blank space at the top. My knowledge of Foundry styling and templating is pretty much nil right now, so I do not know if it is possible to have a dynamic height to the character sheet depending on whether psychic skills are there or not (and same for the tab placement on the right side of the sheet).
