### PR TITLE
Minor bugfix for chat damage buttons

### DIFF
--- a/module/chat.js
+++ b/module/chat.js
@@ -54,7 +54,7 @@ export const addChatMessageButtons = function (msg, html, data) {
     roll.append($(`<div class="dice-damage"><button type="button" data-action="apply-damage"><i class="fas fa-tint"></i></button></div>`))
     roll.find('button[data-action="apply-damage"]').click((ev) => {
       ev.preventDefault();
-      applyChatCardDamage(roll, 1);
+      applyChatCardDamage(roll, 1, 0);
     })
   }
 
@@ -63,7 +63,7 @@ export const addChatMessageButtons = function (msg, html, data) {
     shockMessage.append($(`<div class="dice-damage"><button type="button" data-action="apply-damage"><i class="fas fa-tint"></i></button></div>`))
     shockMessage.find('button[data-action="apply-damage"]').click((ev) => {
       ev.preventDefault();
-      applyChatCardDamage(shockMessage, 1);
+      applyChatCardDamage(shockMessage, 1, 0);
     })
   }
 }


### PR DESCRIPTION
*applyChatCardDamage* was updated to take an index for the chat roll right-click context menu, but the listeners for the damage buttons weren't updated to pass an index parameter when calling it. This would result in an error when trying to use the undefined parameter to index into the array of html elements.