### PR TITLE
pass actor as data.actor instead of actor.system

### DIFF
--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -116,7 +116,7 @@ export class WwnActor extends Actor {
     const rollParts = ["1d20"];
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "above",
         target: this.system.saves[save].value,
@@ -148,7 +148,7 @@ export class WwnActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "below",
         target: this.system.details.morale,
@@ -171,7 +171,7 @@ export class WwnActor extends Actor {
     const rollParts = ["1d10"];
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "instinct",
         target: this.system.details.instinct,
@@ -195,7 +195,7 @@ export class WwnActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "below",
         target: this.system.retainer.loyalty,
@@ -218,7 +218,7 @@ export class WwnActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "table",
         table: {
@@ -260,7 +260,7 @@ export class WwnActor extends Actor {
     const rollParts = ["1d20"];
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "check",
         target: this.system.scores[score].value,
@@ -297,7 +297,7 @@ export class WwnActor extends Actor {
     }
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "hitdice",
       },
@@ -326,7 +326,7 @@ export class WwnActor extends Actor {
       label = "(dungeon)";
     }
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: {
           type: "appearing",
@@ -351,7 +351,7 @@ export class WwnActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: this.system,
+      actor: this,
       roll: {
         type: "skill",
         target: this.system.details.skill,
@@ -381,7 +381,7 @@ export class WwnActor extends Actor {
     const data = this.system;
 
     const rollData = {
-      actor: this.system,
+      actor: this,
       item: attData.item,
       roll: {
         type: "damage",

--- a/module/dice.js
+++ b/module/dice.js
@@ -51,11 +51,21 @@ export class WwnDice {
         // RegEx expression to chop up iL into the chunks needed
         const pattern = /\[(.+)\.([\w]+)\]/;
         const iA = iL.match(pattern);
-        const pack = game.packs.get(iA[1]);
-        if ( game.settings.get("wwn", "hideInstinct") ) {
-          pack.getDocument(iA[2]).then(table => table.draw({rollMode: "gmroll"}));
+        const type = iA[1];
+        const id = iA[2];
+        let tablePromise;
+        if ( type === "RollTable" ) {
+          tablePromise = Promise.resolve(game.tables.get(id))
+        } else if ( type === "Compendium.wwn.instinct") {
+          const pack = game.packs.get('wwn.instinct');
+          tablePromise = pack.getDocument(id);
         } else {
-          pack.getDocument(iA[2]).then(table => table.draw());
+          tablePromise = Promise.reject("not an instinct table")
+        }
+        if ( game.settings.get("wwn", "hideInstinct") ) {
+          tablePromise.then(table => table.draw({rollMode: "gmroll"}));
+        } else {
+          tablePromise.then(table => table.draw());
         }
       }
     }


### PR DESCRIPTION
A fix for https://github.com/SobranDM/foundryvtt-wwn/issues/64. The use of `this.system` as `data.actor` was not affecting the other rolls as they did not use `data.actor` at all, but also fix them so if they use `actor` in the future it will be the expected object.

Loading of the table also was not working, as the type of table is prefixed with `Compendium.` (so `Compendium.wwn.instinct`, while the `packs` collection has `wwn.instinct`. Changed the code so it also works if you use a `RollTable` in the collection, instead of straight from the compendium pack.