### PR TITLE
fix license display under configuration tab

### DIFF
--- a/wwn.css
+++ b/wwn.css
@@ -756,6 +756,8 @@
 
 #settings .wwn.game-license {
   font-size: 12px;
+  padding: 10px;
+  flex-basis: 100%;
 }
 #settings .wwn.game-license .button {
   text-align: center;


### PR DESCRIPTION
Simple CSS fix for license info:
![image](https://github.com/SobranDM/foundryvtt-wwn/assets/97160/ac4601d0-5a4e-480e-b04a-e16cc30c69e8)
